### PR TITLE
Improvements to locked colors

### DIFF
--- a/vmd_plugin/main.tcl
+++ b/vmd_plugin/main.tcl
@@ -743,7 +743,7 @@ proc ::simmerblau::simmerblau_gui {} {
     radiobutton $frc.r6 -text "Linear" -value "linear" -variable ::simmerblau::curveMethod
     pack $frc.r1 $frc.r2 $frc.r3 $frc.r4 $frc.r5 $frc.r6 -side left -expand 1
     pack $frc -fill x
-    ::simmerblau::create_control $pc "Flow intensity" curveAccent 0 5
+    ::simmerblau::create_control $pc "Flow intensity" curveAccent 0 1
     foreach child [winfo children $pc] { if {$child != "$frc" && $child != "$pc.desc"} { pack $child -fill x -expand 1 } }
 
     set pl [labelframe $f.lib -text "Palette library" -padx $framepad -pady 3]

--- a/vmd_plugin/main.tcl
+++ b/vmd_plugin/main.tcl
@@ -56,7 +56,7 @@ proc simmerblau_tk_cb {} {
 
 proc ::simmerblau::get_current_state {} {
     set state {}
-    foreach var {technique colorinator_map colorinator_stops hStart hCycles hStartCenter sMin sMax lMin lMax curveMethod curveAccent useHarvey colorSpace harmony} {
+    foreach var {technique colorinator_map colorinator_stops hStart hCycles hStartCenter sMin sMax lMin lMax curveMethod curveAccent useHarvey colorSpace harmony lockedColors} {
         dict set state $var [set ::simmerblau::$var]
     }
     return $state
@@ -871,6 +871,7 @@ proc ::simmerblau::on_canvas_click {x y} {
 
     if {[dict exists $lockedColors $idx]} {
         dict unset lockedColors $idx
+        ::simmerblau::push_undo_snapshot
     } else {
         # Lock current projected color.
         set ramp [::simmerblau::generate_ramp $::simmerblau::PALETTE_SIZE]
@@ -882,7 +883,8 @@ proc ::simmerblau::on_canvas_click {x y} {
 
         set rgb [lindex $ramp $color_idx]
         dict set lockedColors $idx $rgb
-        }
+        ::simmerblau::push_undo_snapshot
+    }
 
     ::simmerblau::update_preview
     if {$::simmerblau::livePreview} { ::simmerblau::apply_ramp }

--- a/vmd_plugin/main.tcl
+++ b/vmd_plugin/main.tcl
@@ -1160,7 +1160,7 @@ proc ::simmerblau::apply_ramp {} {
             set rgb [lindex $ramp $ramp_i]
             # Respect locked colors.
             if {[dict exists $::simmerblau::lockedColors $ramp_i]} {
-                set [dict get $::simmerblau::lockedColors $ramp_i] rgb
+                set rgb [dict get $::simmerblau::lockedColors $ramp_i]
             }
             lassign $rgb r g b
             color change rgb $vmd_i $r $g $b

--- a/vmd_plugin/main.tcl
+++ b/vmd_plugin/main.tcl
@@ -15,7 +15,8 @@ namespace eval ::simmerblau:: {
     variable w
     variable technique "rampensau"
     # PALETTE_SIZE is the number of colors in VMD's standard palette (0-32).
-    set PALETTE_SIZE 33
+    # Excluding the background color.
+    set PALETTE_SIZE 32
     variable colorinator_map "SBW"
     variable colorinator_stops {{0.00 {0.15 0.55 0.90}} {0.50 {1.00 1.00 1.00}} {1.00 {0.85 0.40 0.05}}}
     variable hStart 180.0
@@ -45,6 +46,7 @@ namespace eval ::simmerblau:: {
     variable dragging_stop_idx -1
     set plugin_title "Simmerblau Colors"
     set label_width 14
+    set font "Helvetica"
 }
 
 proc simmerblau_tk_cb {} {
@@ -578,7 +580,6 @@ proc ::simmerblau::colorinator_snap_spacing {type} {
 }
 
 proc ::simmerblau::simmerblau_gui {} {
-    set font "Helvetica"
     set font_explanation "Times 10 italic"
     set fg_subtle gray50
     set pad 3
@@ -586,6 +587,7 @@ proc ::simmerblau::simmerblau_gui {} {
     set wraplength 400
 
     variable w
+    variable font
 
     if {[winfo exists .simmerblau]} {
         wm deiconify .simmerblau
@@ -862,7 +864,7 @@ proc ::simmerblau::on_canvas_click {x y} {
     if {$x > ($width / 2.0)} return
 
     set height [winfo height $canvas]
-    # We always show 33 slots for the palette side.
+    # We always show PALETTE_SIZE slots for the palette side.
     set num_boxes $::simmerblau::PALETTE_SIZE
     set step [expr {double($height) / $num_boxes}]
     set idx [expr {int(floor($y / $step))}]
@@ -888,6 +890,8 @@ proc ::simmerblau::on_canvas_click {x y} {
 
 proc ::simmerblau::update_preview {args} {
     variable w; if {![winfo exists $w]} return
+    variable font
+    variable targetRange
     set canvas $w.cv
     $canvas delete all
 
@@ -915,6 +919,7 @@ proc ::simmerblau::update_preview {args} {
     set p_ramp [::simmerblau::generate_ramp $num_palette]
 
     set p_step [expr {double($height) / $num_palette}]
+    set vmd_i 0
     for {set i 0} {$i < $num_palette} {incr i} {
         set py [expr {$i * $p_step}]
 
@@ -933,17 +938,29 @@ proc ::simmerblau::update_preview {args} {
         set hex [format "#%02x%02x%02x" [expr {int([lindex $rgb 0]*255)}] [expr {int([lindex $rgb 1]*255)}] [expr {int([lindex $rgb 2]*255)}]]
         $canvas create rectangle 0 $py $half [expr {$py + $p_step}] -fill $hex -outline "#ffffff"
 
-        # Visual indicator for locking.
-        if {$is_locked} {
-            set cx [expr {$half / 2.0}]
-            set cy [expr {$py + $p_step / 2.0}]
-            set r 3
-            # Contrast dot.
-            set dot_fill "white"
-            set lum [expr {0.2126*[lindex $rgb 0] + 0.7152*[lindex $rgb 1] + 0.0722*[lindex $rgb 2]}]
-            if {$lum > 0.5} { set dot_fill "black" }
-            $canvas create oval [expr {$cx-$r}] [expr {$cy-$r}] [expr {$cx+$r}] [expr {$cy+$r}] -fill $dot_fill -outline ""
+        # Skip VMD background color index
+        if {$vmd_i == [colorinfo index [color Display Background]]} {
+            incr vmd_i
         }
+
+        # Visual indicator for locking and color IDs.
+        set cx [expr {$half / 2.0}]
+        set cy [expr {$py + $p_step / 2.0}]
+        # Indicate locked status.
+        set label_text "$vmd_i"
+        if {$is_locked} {
+            set label_text "🔒 $vmd_i"
+        }
+        # Contrast the color ID label.
+        set fill "white"
+        set lum [expr {0.2126*[lindex $rgb 0] + 0.7152*[lindex $rgb 1] + 0.0722*[lindex $rgb 2]}]
+        if {$lum > 0.5} { set fill "black" }
+        # If the target is not 0-32, make the numbers greyed out.
+        if {$targetRange != "0-32"} {
+            set fill "gray70"
+        }
+        $canvas create text [expr {$cx}] [expr {$cy}] -font $font -fill $fill -text $label_text
+        incr vmd_i
     }
 
     # Draw Colorinator stop markers if active.
@@ -1056,21 +1073,26 @@ proc ::simmerblau::apply_ramp {} {
     variable targetRange
     if {$targetRange == "0-32"} {
         set ramp [::simmerblau::generate_ramp $::simmerblau::PALETTE_SIZE]
-        set i 0
-        foreach rgb $ramp {
-            if {$i >= $::simmerblau::PALETTE_SIZE} break
-            # Skip the background color.
-            if {$i == [colorinfo index [color Display Background]]} {
-                incr i
-                continue
+        # Which VMD color to write to.
+        set vmd_i 0
+        # Iterate through ramp colors.
+        for { set ramp_i 0 } { $ramp_i < $::simmerblau::PALETTE_SIZE } { incr ramp_i } {
+            # Don't write above the 0-32 range by accident.
+            if {$vmd_i > 32} {
+                error "Assertion failed: vmd_index out of bounds."
             }
+            # Skip the background color.
+            if {$vmd_i == [colorinfo index [color Display Background]]} {
+                incr vmd_i
+            }
+            set rgb [lindex $ramp $ramp_i]
             # Respect locked colors.
-            if {[dict exists $::simmerblau::lockedColors $i]} {
-                set rgb [dict get $::simmerblau::lockedColors $i]
+            if {[dict exists $::simmerblau::lockedColors $ramp_i]} {
+                set [dict get $::simmerblau::lockedColors $ramp_i] rgb
             }
             lassign $rgb r g b
-            color change rgb $i $r $g $b
-            incr i
+            color change rgb $vmd_i $r $g $b
+            incr vmd_i
         }
     } else {
         # Update VMD color scale.

--- a/vmd_plugin/main.tcl
+++ b/vmd_plugin/main.tcl
@@ -39,6 +39,7 @@ namespace eval ::simmerblau:: {
     variable snapshotAfterID ""
     # This dictionary maps the color index to its {r g b} values.
     variable lockedColors {}
+    variable dragging_locked_idx -1
     variable selected_stop_idx 0
     variable cur_r 0.0
     variable cur_g 0.0
@@ -937,8 +938,9 @@ proc ::simmerblau::update_preview {args} {
             set is_locked 0
         }
 
+        set tags [list "color_rect" "color_$i"]
         set hex [format "#%02x%02x%02x" [expr {int([lindex $rgb 0]*255)}] [expr {int([lindex $rgb 1]*255)}] [expr {int([lindex $rgb 2]*255)}]]
-        $canvas create rectangle 0 $py $half [expr {$py + $p_step}] -fill $hex -outline "#ffffff"
+        $canvas create rectangle 0 $py $half [expr {$py + $p_step}] -fill $hex -outline "#ffffff" -tags $tags
 
         # Skip VMD background color index
         if {$vmd_i == [colorinfo index [color Display Background]]} {
@@ -997,9 +999,10 @@ proc ::simmerblau::update_preview {args} {
 proc ::simmerblau::on_mouse_down {x y} {
     variable w
     variable dragging_stop_idx
+    variable dragging_locked_idx
     set canvas $w.cv
 
-    # First, check if a stop marker was clicked.
+    # Check if a stop marker or color rect was clicked.
     set items [$canvas find overlapping [expr {$x-3}] [expr {$y-3}] [expr {$x+3}] [expr {$y+3}]]
     foreach item $items {
         set tags [$canvas gettags $item]
@@ -1012,63 +1015,130 @@ proc ::simmerblau::on_mouse_down {x y} {
                 }
             }
         }
+        if {[lsearch $tags "color_rect"] != -1} {
+            foreach tag $tags {
+                if {[scan $tag "color_%d" idx] == 1} {
+                    set dragging_locked_idx $idx
+                    return
+                }
+            }
+        }
     }
-
-    # If no marker was clicked, fall back to the locking logic for the palette.
-    ::simmerblau::on_canvas_click $x $y
 }
 
 proc ::simmerblau::on_mouse_move {x y} {
     variable dragging_stop_idx
-    if {$dragging_stop_idx < 0} return
-
+    variable dragging_locked_idx
     variable w
     set canvas $w.cv
-    set height [winfo height $canvas]
-    if {$height <= 1} { set height 700 }
 
-    # Calculate the normalized position.
-    set pos [expr {double($y) / $height}]
-    if {$pos < 0.0} { set pos 0.0 }
-    if {$pos > 1.0} { set pos 1.0 }
+    if {$dragging_stop_idx >= 0} {
+        set height [winfo height $canvas]
+        if {$height <= 1} { set height 700 }
 
-    # Update the stop position during the drag.
-    lset ::simmerblau::colorinator_stops $dragging_stop_idx 0 $pos
-    ::simmerblau::update_preview
+        # Calculate the normalized position.
+        set pos [expr {double($y) / $height}]
+        if {$pos < 0.0} { set pos 0.0 }
+        if {$pos > 1.0} { set pos 1.0 }
+
+        # Update the stop position during the drag.
+        lset ::simmerblau::colorinator_stops $dragging_stop_idx 0 $pos
+        ::simmerblau::update_preview
+    }
 }
 
 proc ::simmerblau::on_mouse_up {x y} {
     variable dragging_stop_idx
-    if {$dragging_stop_idx < 0} return
-
-    # Commit the final position and sort.
-    set idx $dragging_stop_idx
-    set dragging_stop_idx -1
-
+    variable dragging_locked_idx
+    variable lockedColors
     variable w
     set canvas $w.cv
-    set height [winfo height $canvas]
-    if {$height <= 1} { set height 700 }
-    set pos [expr {double($y) / $height}]
-    if {$pos < 0.0} { set pos 0.0 }
-    if {$pos > 1.0} { set pos 1.0 }
 
-    # Find the new index of the stop after sorting.
-    set old_rgb [lindex [lindex $::simmerblau::colorinator_stops $idx] 1]
-    lset ::simmerblau::colorinator_stops $idx 0 $pos
-    set ::simmerblau::colorinator_stops [lsort -real -index 0 $::simmerblau::colorinator_stops]
+    if {$dragging_stop_idx >= 0} {
+        # Dragging a stop.
 
-    set new_idx 0
-    foreach stop $::simmerblau::colorinator_stops {
-        if {abs([lindex $stop 0] - $pos) < 0.0001 && [lindex $stop 1] == $old_rgb} {
-            break
+        # Commit the final position and sort.
+        set idx $dragging_stop_idx
+        set dragging_stop_idx -1
+
+        set height [winfo height $canvas]
+        if {$height <= 1} { set height 700 }
+        set pos [expr {double($y) / $height}]
+        if {$pos < 0.0} { set pos 0.0 }
+        if {$pos > 1.0} { set pos 1.0 }
+
+        # Find the new index of the stop after sorting.
+        set old_rgb [lindex [lindex $::simmerblau::colorinator_stops $idx] 1]
+        lset ::simmerblau::colorinator_stops $idx 0 $pos
+        set ::simmerblau::colorinator_stops [lsort -real -index 0 $::simmerblau::colorinator_stops]
+
+        set new_idx 0
+        foreach stop $::simmerblau::colorinator_stops {
+            if {abs([lindex $stop 0] - $pos) < 0.0001 && [lindex $stop 1] == $old_rgb} {
+                break
+            }
+            incr new_idx
         }
-        incr new_idx
-    }
 
-    # A full refresh is triggered upon release to update the editor rows.
-    ::simmerblau::colorinator_select_stop $new_idx 1
-    ::simmerblau::update_preview
+        # A full refresh is triggered upon release to update the editor rows.
+        ::simmerblau::colorinator_select_stop $new_idx 1
+        ::simmerblau::update_preview
+    } elseif {$dragging_locked_idx >= 0} {
+        # Dragging a locked item.
+
+        # Drag from.
+        set idx_from $dragging_locked_idx
+        set dragging_locked_idx -1
+        # Drop to.
+        set idx_to -1
+        set items [$canvas find overlapping [expr {$x-3}] [expr {$y-3}] [expr {$x+3}] [expr {$y+3}]]
+        foreach item $items {
+            set tags [$canvas gettags $item]
+            if {[lsearch $tags "color_rect"] != -1} {
+                foreach tag $tags {
+                    if {[scan $tag "color_%d" idx] == 1} {
+                        set idx_to $idx
+                        break
+                    }
+                }
+            }
+
+            # Short circuit if within same rect.
+            if {$idx_to == $idx_from} {
+                ::simmerblau::on_canvas_click $x $y
+                return
+            }
+
+            if {$idx_to >= 0} {
+                # We have both a from and to.
+                if {![dict exists $lockedColors $idx_from]} {
+                    # UX choice: only be able to drag locked colors.
+                    return
+                }
+
+                set rgb_from [dict get $lockedColors $idx_from]
+
+                if {[dict exists $lockedColors $idx_to]} {
+                    # If target is locked too, swap it back.
+                    dict set lockedColors $idx_from [dict get $lockedColors $idx_to]
+                } else {
+                    # Otherwise, unlock it.
+                    dict unset lockedColors $idx_from
+                }
+
+                # Move source to target.
+                dict set lockedColors $idx_to $rgb_from
+
+                ::simmerblau::push_undo_snapshot
+                ::simmerblau::update_preview
+                return
+            }
+        }
+
+    } else {
+        # If no meaningful dragging is happening, fall back to click logic.
+        ::simmerblau::on_canvas_click $x $y
+    }
 }
 
 proc ::simmerblau::apply_ramp {} {

--- a/vmd_plugin/main.tcl
+++ b/vmd_plugin/main.tcl
@@ -1066,8 +1066,7 @@ proc ::simmerblau::apply_ramp {} {
             }
             # Respect locked colors.
             if {[dict exists $::simmerblau::lockedColors $i]} {
-                incr i
-                continue
+                set rgb [dict get $::simmerblau::lockedColors $i]
             }
             lassign $rgb r g b
             color change rgb $i $r $g $b

--- a/vmd_plugin/rampensau.tcl
+++ b/vmd_plugin/rampensau.tcl
@@ -19,7 +19,7 @@ namespace eval ::simmerblau::logic::rampensau {
                 return [list [expr {sin($limit + $t * $limit - $accent)}] [expr {cos(-$limit + $t * $limit + $accent)}]]
             }
             "power" {
-                return [list [expr {pow($t, $accent)}] [expr {pow($t, $accent)}]]
+                return [list [expr {pow(1.0 - $t, 1.0 - $accent)}] [expr {pow($t, 1.0 - $accent)}]]
             }
             "powY" {
                 return [list [expr {pow(1.0 - $t, $accent)}] [expr {pow($t, 1.0 - $accent)}]]


### PR DESCRIPTION
1. I noticed that the formula for Power was different to how rampensau did it, so I changed it to how rampensau actually does it. If it was intentional I can of course remove that change.

I also changed the slider accent slider to be from 0 to 1 instead of 0 to 5. 0 to 5 is not a correct range for some of the curve methods.

2. Colors were not being applied to VMD if they were locked. Fixing this.

3. Only have 32 colors in the picker, so the skipping of the background color is clearer. Add color IDs to the UI. Show locked status with an icon.

4. Locking/unlocking was not part of undo/redo, fixing this.

5. Added support for drag and dropping locked colors, so the order can be changed. Currently I have made the UX decision to disallow dragging unlocked colors. Note, that there is no visual indication of dragging at the moment, which could be fixed later.

Edit: another note - the 3 pixel cutoff for "canvas find overlapping" is maybe a bit generous for the color rect drag and drop, but I left it as is, as with a smaller cutoff it seems to not allow clicking on the color ID text.